### PR TITLE
Support for raw POST requests is added

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -63,6 +63,10 @@ code:
 
 This works for other HTTP methods as well, such as `PUT`, `DELETE`, and `HEAD`.
 
+For raw POST requests use `RAW_POST` method and pass raw POST content
+as `body` keyword argument:
+
+    some_api.some_method.RAW_POST(body='REQUEST BODY IS HERE')
 
 Handling authentication
 -----------------------

--- a/dolt/__init__.py
+++ b/dolt/__init__.py
@@ -8,7 +8,7 @@ import urllib
 class Dolt(object):
 
     def __init__(self, http=None):
-        self._supported_methods = ("GET", "POST", "PUT", "HEAD", "DELETE",)
+        self._supported_methods = ("GET", "POST", "PUT", "HEAD", "DELETE", "RAW_POST")
         self._attribute_stack = []
         self._method = "GET"
         self._posts = []
@@ -33,6 +33,10 @@ class Dolt(object):
         return self._params_template % urllib.urlencode(params)
 
     def _generate_body(self):
+        if self._method == 'RAW_POST':
+            self._method = 'POST'
+            return self._params['body']
+
         if self._method == 'POST':
             internal_params = self._params.copy()
             if 'GET' in internal_params:

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -211,6 +211,23 @@ class TestOfDolt(unittest.TestCase):
         dolt.foo.DELETE()
         verify_all(dolt._http)
 
+    def test_supports_post_method(self):
+        dolt = testable_dolt()
+        dolt._http.request("/foo", "POST", body='x=1').AndReturn(({}, "{}"))
+        replay_all(dolt._http)
+
+        dolt.foo.POST(x='1')
+        verify_all(dolt._http)
+
+    def test_supports_raw_post_body(self):
+        dolt = testable_dolt()
+        dolt._http.request("/foo", "POST", body='hello').AndReturn(({}, "{}"))
+        replay_all(dolt._http)
+
+        dolt.foo.RAW_POST(body='hello')
+        verify_all(dolt._http)
+
+
     def test_supports_various_methods_as_attributes_as_well(self):
         dolt = testable_dolt()
 
@@ -312,6 +329,17 @@ class TestOfDolt(unittest.TestCase):
 
         # second call shouldn't raise an exception
         self.assertEqual(dolt.foo()['foo'], 'bar')
+
+    def test_getitem_allows_magic(self):
+        dolt = testable_dolt()
+        for method in dolt._supported_methods:
+            dolt._http.request("/%s" % method, "GET", body=None).AndReturn(({}, "{}"))
+        replay_all(dolt._http)
+
+        for method in dolt._supported_methods:
+            dolt[method]()
+
+        verify_all(dolt._http)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As described in #5 with one change: argument is called 'body', not 'data'. 
