### PR TITLE
Cloneable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 MANIFEST
 dist/*
 build/*
+*.egg-info

--- a/dolt/__init__.py
+++ b/dolt/__init__.py
@@ -1,72 +1,247 @@
 import httplib2
-try:
-    import json as simplejson
-except ImportError:
-    import simplejson
 import urllib
+
+try:
+    import json
+except ImportError:
+    import simplejson as json
+
+try:
+    from decorator import decorator
+except ImportError:
+    # No decorator package available. Create a no-op "decorator".
+    def decorator(f):
+        def decorate(_func):
+            def inner(*args, **kwargs):
+                return f(_func, *args, **kwargs)
+            return inner
+        return decorate    
+
+
+@decorator
+def _makes_clone(_func, *args, **kw):
+    """
+    A decorator that returns a clone of the current object so that
+    we can re-use the object for similar requests.
+    """
+    self = args[0]._clone()
+    _func(self, *args[1:], **kw)
+    return self
 
 class Dolt(object):
 
     def __init__(self, http=None):
-        self._supported_methods = ("GET", "POST", "PUT", "HEAD", "DELETE",)
+        self._supported_methods = ("GET", "POST", "PUT", "HEAD", "DELETE", "OPTIONS")
         self._attribute_stack = []
         self._method = "GET"
-        self._posts = []
+        self._body = None
         self._http = http or httplib2.Http()
         self._params = {}
+        self._headers = {}
         self._api_url = ""
         self._url_template = '%(domain)s/%(generated_url)s'
         self._stack_collapser = "/".join
         self._params_template = '?%s'
 
     def __call__(self, *args, **kwargs):
-        self._attribute_stack += [str(a) for a in args]
-        self._params = kwargs
-        try:
-            body = self._generate_body()
-            response, data = self._http.request(self.get_url(), self._method, body=body)
-            return self._handle_response(response, data)
-        finally:
-            self._attribute_stack = []
+        url = self.get_url(*[str(a) for a in args], **kwargs) 
+
+        response, data = self._http.request(url, self._method, body=self._body, headers=self._headers)
+        return self._handle_response(response, data)
 
     def _generate_params(self, params):
         return self._params_template % urllib.urlencode(params)
 
-    def _generate_body(self):
-        if self._method == 'POST':
-            internal_params = self._params.copy()
-            if 'GET' in internal_params:
-                del internal_params['GET']
-            return self._generate_params(internal_params)[1:]
-
     def _handle_response(self, response, data):
-        return simplejson.loads(data)
+        """
+        Deserializes JSON if the content-type matches, otherwise returns the response
+        body as is.
+        """
+        if data and response.get('content-type') in (
+            'application/json', 
+            'application/x-javascript',
+            'text/javascript',
+            'text/x-javascript',
+            'text/x-json'
+        ):
+            return json.loads(data)
+        else:
+            return data
 
+    @_makes_clone
     def __getitem__(self, name):
+        """
+        Adds `name` to the URL path.
+        """
         self._attribute_stack.append(name)
         return self
 
+    @_makes_clone
     def __getattr__(self, name):
+        """
+        Sets the HTTP method for the request or adds `name` to the URL path.
+
+        ::
+            
+            >>> dolt.GET._method == 'GET'
+            True
+            >>> dolt.foo.bar.get_url()
+            '/foo/bar'
+
+        """
         if name in self._supported_methods:
             self._method = name
         elif not name.endswith(')'):
             self._attribute_stack.append(name)
         return self
 
-    def get_url(self):
+    @_makes_clone
+    def with_params(self, **params):
+        """
+        Add URL query parameters to the request.
+        """
+        self._params.update(params)
+        return self
+
+    @_makes_clone
+    def with_body(self, body=None, **params):
+        """
+        Add a body to the request.
+
+        When `body` is a:
+            - string, it will be used as is. 
+            - dict or list of (key, value) pairs, it will be form encoded
+            - None, remove request body
+            - anything else, a TypeError will be raised 
+            
+        If `body` is a dict or None you can also pass in keyword
+        arguments to add to the body.
+
+        ::
+            >>> dolt.with_body(dict(key='val'), foo='bar')._body
+            'foo=bar&key=val'
+        """
+
+        if isinstance(body, (tuple, list)):
+            body = dict(body)
+
+        if params:
+            # Body must be None or able to be a dict
+            if isinstance(body, dict):
+                body.update(params)
+            elif body is None:
+                body = params
+            else:
+                raise ValueError('Body must be None or a dict if used with params, got: %r' % body)
+
+        if isinstance(body, basestring):
+            self._body = body
+        elif isinstance(body, dict):
+            self._body = urllib.urlencode(body)
+        elif body is None:
+            self._body = None
+        else:
+            raise TypeError('Invalid body type %r' % body)        
+        
+
+        return self
+
+    def with_json(self, data=None, **params):
+        """
+        Add a json body to the request.   
+        
+        :param data: A json string, a dict, or a list of key, value pairs
+        :param params: A dict of key value pairs to JSON encode     
+        """
+        if isinstance(data, (tuple, list)):
+            data = dict(data)
+
+        if params:
+            # data must be None or able to be a dict
+            if isinstance(data, dict):
+                data.update(params)
+            elif data is None:
+                data = params
+            else:
+                raise ValueError('Data must be None or a dict if used with params, got: %r' % data)
+
+        req = self.with_headers({'Content-Type': 'application/json', 'Accept': 'application/json'})
+        if isinstance(data, basestring):
+            # Looks like it's already been encoded
+            return req.with_body(data)
+        else:
+            return req.with_body(json.dumps(data))
+
+    @_makes_clone
+    def with_headers(self, headers=None, **params):
+        """
+        Add headers to the request.   
+        
+        :param headers: A dict, or a list of key, value pairs
+        :param params: A dict of key value pairs   
+        """        
+        if isinstance(headers, (tuple, list)):
+            headers = dict(headers)
+
+        if params:
+            if isinstance(headers, dict):
+                headers.update(params)
+            elif headers is None:
+                headers = params
+
+        self._headers.update(headers)
+        return self
+
+    def get_url(self, *paths, **params):
+        """
+        Returns the URL for this request.
+
+        :param paths: Additional URL path parts to add to the request
+        :param params: Additional query parameters to add to the request
+        """
+        path_stack = self._attribute_stack[:]
+        if paths:
+            path_stack.extend(paths)
+
+        u = self._stack_collapser(path_stack)
         url = self._url_template % {
             "domain": self._api_url,
-            "generated_url" : self._stack_collapser(self._attribute_stack),
+            "generated_url" : u,
         }
-        if len(self._params):
+
+        if self._params or params:
             internal_params = self._params.copy()
-            if self._method == 'POST':
-                if "GET" not in internal_params:
-                    return url
-                internal_params = internal_params['GET']
+            internal_params.update(params)
             url += self._generate_params(internal_params)
 
         return url
+
+    def _clone(self):
+        """
+        Clones the state of the current operation.
+
+        The state is cloned so that you can freeze the state at a certain point for re-use.
+
+        ::
+
+            >>> cat = dolt.cat
+            >>> cat.get_url()
+            '/cat'
+            >>> o = cat.foo
+            >>> o.get_url()
+            '/cat/foo'
+            >>> cat.get_url()
+            '/cat'
+
+        """
+        cls = self.__class__
+        q = cls.__new__(cls)
+        q.__dict__ = self.__dict__.copy()
+        q._params = self._params.copy()
+        q._headers = self._headers.copy()
+        q._attribute_stack = self._attribute_stack[:]
+
+        return q
 
     try:
         __IPYTHON__
@@ -75,9 +250,10 @@ class Dolt(object):
                 '_supported_methods',
                 '_attribute_stack',
                 '_method',
-                '_posts',
+                '_body',
                 '_http',
                 '_params',
+                '_headers',
                 '_api_url',
                 '_url_template',
                 '_stack_collapser',

--- a/dolt/helpers.py
+++ b/dolt/helpers.py
@@ -1,0 +1,22 @@
+import base64
+
+def add_basic_auth(dolt, username, password):
+    """
+    Send basic auth username and password.
+
+    Normally you can use httplib2.Http.add_credentials() to add username and password.
+    However this has two disadvantages.
+
+    1. Some poorly implemented APIs require basic auth but don't send a
+       "401 Authorization Required". Httplib2 won't send basic auth unless the server
+       responds this way (see http://code.google.com/p/httplib2/issues/detail?id=130)
+    2. Doing a request just to get a "401 Authorization Required" header is a waste
+       of time and bandwidth. If you know you need basic auth, you might as well
+       send it right up front.
+
+    By using `with_basic_auth`, the username and password will be sent proactively
+    without waiting for a 401 header.
+    """
+    return dolt.with_headers(
+        Authorization='Basic %s' % base64.b64encode('%s:%s' % (username, password)).strip()
+    )

--- a/examples/flickr.py
+++ b/examples/flickr.py
@@ -8,20 +8,11 @@ class Flickr(Dolt):
         super(self.__class__, self).__init__(*args, **kwargs)
         self._api_key = api_key
         self._api_url = "http://api.flickr.com"
-        self._url_template = "%(domain)s/services/rest/?format=json&method=%(generated_url)s"
-        self._stack_collapser = self._collapse_stack
+        self._url_template = "%(domain)s/services/rest/?format=json&method=flickr.%(generated_url)s"
+        self._stack_collapser = '.'.join
         self._params_template = "&%s"
-
-    def _collapse_stack(self, *args, **kwargs):
-        self._attribute_stack[0:0] = "flickr",
-        return ".".join(self._attribute_stack)
-
-    def get_url(self):
-        url = super(self.__class__, self).get_url()
-        return url + "&api_key=%s" % self._api_key
-
-    def _handle_response(self, response, data):
-        return super(self.__class__, self)._handle_response(response, data[14:-1])
+        self._params['api_key'] = self._api_key
+        self._params['nojsoncallback'] = 1
 
 if __name__ == "__main__":
     api_key = raw_input("Flickr API key: ")

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     url='http://github.com/tswicegood/Dolt/',
     packages=packages,
     package_data={'dolt': data_files},
+    install_requires=['httplib2'],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Web Environment',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ for dirpath, dirnames, filenames in os.walk('dolt'):
 
 setup(
     name='Dolt',
-    version='0.5.1', # TODO: move this into Dolt.get_version()
+    version='0.6.0', # TODO: move this into Dolt.get_version()
     description='A dumb little wrapper around RESTful interfaces',
     author='Travis Swicegood',
     author_email='development@domain51.com',


### PR DESCRIPTION
I've found Dolt useful and made some changes to make it more usable for some use cases I came across. This might be a little more involved than the direction you're looking for for Dolt. I've updated the README and documented the code for the changes.

The most noticeable change is that attribute and with_\* methods return a cloned object. This allows you to re-use Dolt objects. It also eliminates the need to reset the attribute stack. I've also added with_body to make setting the POST body more clear, with_json to specifically send a JSON encoded body, and with_headers to be able to send headers. I also did some cleanup and added more documentation. Because of the addition of with_json and with_body, **call** always encodes kwargs as query params. This avoids confusion on how sometimes it did form post and sometimes query params. It also allows you to send a form body and have query params.

The one loose end is the mosso api. I wasn't sure about the best way to update that because I'm not familiar with that API or how people are using it with Dolt. In general, instead of using _generate_body, with_json should be used instead. should_contain_values could possibly be a part of with_json, but I also think it's odd that the user doesn't handle wrapping the params with `servers` since they need to know enough about the API in order to use Dolt.
