### PR TITLE
Fix JSON handling for Content-Type headers with additional parameters.

### DIFF
--- a/dolt/__init__.py
+++ b/dolt/__init__.py
@@ -57,7 +57,9 @@ class Dolt(object):
         Deserializes JSON if the content-type matches, otherwise returns the response
         body as is.
         """
-        if data and response.get('content-type') in (
+        # Content-Type headers can include additional parameters(RFC 1521), so
+        # we split on ; to match against only the type/subtype
+        if data and response.get('content-type', '').split(';')[0] in (
             'application/json', 
             'application/x-javascript',
             'text/javascript',

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -414,6 +414,18 @@ class TestOfDolt(unittest.TestCase):
         self.assertTrue('Authorization' in dolt._headers)
         self.assertTrue(dolt._headers['Authorization'].startswith('Basic '))
 
+    def test_returns_parsed_json_with_content_type_params(self):
+        dolt = testable_dolt()
+        response_return = {"foo": 1}
+        response_headers = {'content-type': 'application/json; param=bar'}
+        dolt_request(dolt, "/foo", "GET", response_headers=response_headers,
+                     response_body=json.dumps(response_return))
+        replay_all(dolt._http)
+
+        self.assertEqual(dolt.foo(), response_return)
+
+        verify_all(dolt._http)
+
 if __name__ == '__main__':
     unittest.main()
 


### PR DESCRIPTION
A quick fix to support JSON decoding when the returned `Content-Type` header contains parameters.  For example, GitHub returns `Content-Type: application/json; charset=utf-8`:

```
$ curl -I https://github.com/api/v2/json/user/show/JNRowe |& grep Content-Type
Content-Type: application/json; charset=utf-8
```

Thanks,

James
